### PR TITLE
Fixes dangling map key

### DIFF
--- a/index.js
+++ b/index.js
@@ -743,8 +743,7 @@ Orvibo.prototype.updateDevice = function(device, table, data) {
     macPadding: args.device.macPadding,
     commandID: "746d",
     blank: "00000000",
-    table: args.table, "04"
-
+    table: args.table || "04"
   })
 }
 


### PR DESCRIPTION
At least in Node 5.x dangling keys with no value are a syntax error, hence for example none of the examples will run.
